### PR TITLE
Add xUnit tests for Program.Main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
 # Knuth 4B exercise
 
 exercise backtrace for 7.2.2.1 398.
+
+## Running tests
+
+The `dlx.sln` solution includes a regression test project. Execute all tests
+with:
+
+```bash
+dotnet test pentomino_programs/dlx/dlx.sln
+```

--- a/pentomino_programs/dlx.Tests/ProgramTests.cs
+++ b/pentomino_programs/dlx.Tests/ProgramTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.IO;
+using System.Reflection;
+using Xunit;
+
+namespace ImprovedPentominoSolver.Tests
+{
+    public class ProgramTests
+    {
+        [Fact]
+        public void SolveSelectedPieces()
+        {
+            var method = typeof(Program).GetMethod("Main", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+
+            var originalOut = Console.Out;
+            var originalIn = Console.In;
+            using var writer = new StringWriter();
+            using var reader = new StringReader(string.Empty);
+            Console.SetOut(writer);
+            Console.SetIn(reader);
+            try
+            {
+                method.Invoke(null, new object[] { new[] { "-l", "-y", "-v", "-t", "-w", "-z" } });
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+                Console.SetIn(originalIn);
+            }
+
+            var output = writer.ToString();
+            Assert.Contains("Solution found!", output);
+            Assert.Contains("boardField is 5, 6", output);
+            Assert.Contains("T V V V L", output);
+        }
+    }
+}

--- a/pentomino_programs/dlx.Tests/dlx.Tests.csproj
+++ b/pentomino_programs/dlx.Tests/dlx.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\dlx\dlx.csproj" />
+  </ItemGroup>
+</Project>

--- a/pentomino_programs/dlx/dlx.sln
+++ b/pentomino_programs/dlx/dlx.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dlx", "dlx.csproj", "{CFA5B2D0-F30E-4233-8317-E2B61FEA698F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dlx.Tests", "dlx.Tests\dlx.Tests.csproj", "{2F354FEF-F73B-449D-8621-FCDD54C94461}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,8 +28,20 @@ Global
 		{CFA5B2D0-F30E-4233-8317-E2B61FEA698F}.Release|x64.ActiveCfg = Release|Any CPU
 		{CFA5B2D0-F30E-4233-8317-E2B61FEA698F}.Release|x64.Build.0 = Release|Any CPU
 		{CFA5B2D0-F30E-4233-8317-E2B61FEA698F}.Release|x86.ActiveCfg = Release|Any CPU
-		{CFA5B2D0-F30E-4233-8317-E2B61FEA698F}.Release|x86.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {CFA5B2D0-F30E-4233-8317-E2B61FEA698F}.Release|x86.Build.0 = Release|Any CPU
+                {2F354FEF-F73B-449D-8621-FCDD54C94461}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {2F354FEF-F73B-449D-8621-FCDD54C94461}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {2F354FEF-F73B-449D-8621-FCDD54C94461}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {2F354FEF-F73B-449D-8621-FCDD54C94461}.Debug|x64.Build.0 = Debug|Any CPU
+                {2F354FEF-F73B-449D-8621-FCDD54C94461}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {2F354FEF-F73B-449D-8621-FCDD54C94461}.Debug|x86.Build.0 = Debug|Any CPU
+                {2F354FEF-F73B-449D-8621-FCDD54C94461}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {2F354FEF-F73B-449D-8621-FCDD54C94461}.Release|Any CPU.Build.0 = Release|Any CPU
+                {2F354FEF-F73B-449D-8621-FCDD54C94461}.Release|x64.ActiveCfg = Release|Any CPU
+                {2F354FEF-F73B-449D-8621-FCDD54C94461}.Release|x64.Build.0 = Release|Any CPU
+                {2F354FEF-F73B-449D-8621-FCDD54C94461}.Release|x86.ActiveCfg = Release|Any CPU
+                {2F354FEF-F73B-449D-8621-FCDD54C94461}.Release|x86.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add `dlx.Tests` xUnit test project referencing `dlx`
- test `Program.Main` via reflection
- register the test project in `dlx.sln`
- document running `dotnet test`

## Testing
- `dotnet test pentomino_programs/dlx/dlx.sln` *(fails: `dotnet` not found)*